### PR TITLE
Fixes #4: Competition Theme Management

### DIFF
--- a/client/src/components/Groups/Groups.js
+++ b/client/src/components/Groups/Groups.js
@@ -130,7 +130,8 @@ export default function Groups() {
 				eventTabs.push({
 					label: `${activityKey[event.id]}`,
 					value: tabs.length + eventTabs.length + 1,
-					Icon: <CubingIcon eventId={event.id} />,
+					Icon: <CubingIcon eventId={event.id} style={{color:`${theme.palette.competitionPrimary.main}`}}
+					/>,
 					Component: EventGroups,
 					id: event.id,
 				})

--- a/client/src/components/IconTabs/IconTabs.js
+++ b/client/src/components/IconTabs/IconTabs.js
@@ -5,7 +5,7 @@ import Tabs from '@material-ui/core/Tabs'
 import Tab from '@material-ui/core/Tab'
 
 const useTabsStyles = makeStyles(({ spacing, palette }) => {
-	const indicatorBackground = 'rgba(255, 255, 255, .2)'
+	const indicatorBackground = palette.type === 'dark' ? 'rgba(255, 255, 255, .2)' : 'rgba(0,0,0,0.2)'
 	const borderRadius = spacing(1)
 	return {
 		root: {

--- a/client/src/components/Overview/OverviewFilterChips.js
+++ b/client/src/components/Overview/OverviewFilterChips.js
@@ -2,6 +2,7 @@ import React from 'react'
 import Chip from '@material-ui/core/Chip'
 import Grid from '@material-ui/core/Grid'
 import { assignedTo } from '../../logic/schedule'
+import { useTheme } from '@material-ui/core'
 
 export default function OverviewFilterChips({
 	venues,
@@ -28,6 +29,7 @@ export default function OverviewFilterChips({
 			  )
 			: setUnselectedAssignments([...unselectedAssignments, name])
 	}
+	const theme = useTheme()
 	return (
 		<Grid container direction='column' spacing={2}>
 			<Grid item>
@@ -54,7 +56,10 @@ export default function OverviewFilterChips({
 						onClick={() => updateSelectedAssignments(duty)}
 						key={duty}
 						label={assignedTo(duty)}
-						color={unselectedAssignments.includes(duty) ? 'default' : 'primary'}
+						style={{
+							backgroundColor: `${!unselectedAssignments.includes(duty) ? theme.palette.competitionPrimary.main : theme.palette.action.selected}`,
+							color: `${!unselectedAssignments.includes(duty) ? theme.palette.getContrastText(theme.palette.competitionPrimary.main) : theme.palette.text.primary}`,
+						}}
 					/>
 				))}
 			</Grid>

--- a/client/src/components/Results/Results.js
+++ b/client/src/components/Results/Results.js
@@ -33,7 +33,6 @@ export default function Results() {
 	const theme = useTheme()
 	const largeScreen = useMediaQuery(theme.breakpoints.up('lg'))
 	const mediumScreen = useMediaQuery(theme.breakpoints.up('md'))
-
 	const { loading, error, data } = useQuery(COMPETITION_OPEN_ROUNDS_QUERY, {
 		variables: { competitionId: competitionId },
 	})
@@ -70,6 +69,7 @@ export default function Results() {
 						<CubingIcon
 							eventId={eventId}
 							small={!mediumScreen && !largeScreen}
+							style={{color:`${theme.palette.competitionPrimary.main}`}}
 						/>
 					),
 					Component: EventResults,

--- a/client/src/components/common/EventList.js
+++ b/client/src/components/common/EventList.js
@@ -12,13 +12,13 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(1),
     '&:hover': {
       opacity: 0.7,
-      color: theme.palette.primary.main
+      color: theme.palette.competitionPrimary.main
     }
   },
   iconSelect: {
     fontSize: 20,
     padding: theme.spacing(1),
-    color: theme.palette.primary.main,
+    color: theme.palette.competitionPrimary.main,
     '&:hover': {
       opacity: 0.7
     }

--- a/client/src/components/common/Footer.js
+++ b/client/src/components/common/Footer.js
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 const Footer = () => {
-	const toggleTheme = useContext(ToggleThemeContext)
+	const {toggleTheme} = useContext(ToggleThemeContext)
 	const theme = useTheme()
 	const classes = useStyles()
 	return (

--- a/client/src/components/common/Header.js
+++ b/client/src/components/common/Header.js
@@ -20,9 +20,8 @@ import LockIcon from "@material-ui/icons/Lock";
 import VisibilityIcon from "@material-ui/icons/Visibility";
 import Link from "@material-ui/core/Link";
 import { isAdmin } from "../../logic/user";
-import SvgIcon from "@material-ui/core/SvgIcon";
-import IconButton from "@material-ui/core/IconButton";
-import NodusIcon from "./nodus-orange";
+import useScrollTrigger from '@material-ui/core/useScrollTrigger';
+import Slide from '@material-ui/core/Slide';
 import ProfilePopover from "./ProfilePopover";
 
 const useStyles = makeStyles((theme) => ({
@@ -36,14 +35,31 @@ const useStyles = makeStyles((theme) => ({
 		marginLeft: theme.spacing(1),
 	},
 	titleIcon: {
+		maxHeight:'10%',
 		marginRight: theme.spacing(2),
 	},
 	username: {
 		marginRight: theme.spacing(1),
 	},
+	container: theme.mixins.toolbar
 }));
 
-export default function Header({ match: m }) {
+function HideOnScroll(props) {
+	const { children, window } = props;
+	const trigger = useScrollTrigger({ target: window ? window() : undefined });
+  
+	return (
+	  <Slide appear={false} direction="down" in={!trigger}>
+		{children}
+	  </Slide>
+	);
+  }
+  
+  
+
+
+
+export default function Header() {
 	// TODOp1: This rerenders/remounts EVERY TIME THE LOCATION CHANGES IN WINDOW
 	const match = useRouteMatch("/competitions/:competitionId/:tab?") || {
 		params: {
@@ -63,7 +79,9 @@ export default function Header({ match: m }) {
 	}, [match.params.competitionId, match.params.tab]);
 	const classes = useStyles();
 	return (
-		<AppBar position='sticky' color='primary' className={classes.appBar}>
+		<React.Fragment>
+		<HideOnScroll>
+		<AppBar className={classes.appBar} color='primary'>
 			<Toolbar spacing={2} className={classes.titleIcon}>
 				<Typography
 					component={Link}
@@ -130,5 +148,8 @@ export default function Header({ match: m }) {
 				/>
 			)}
 		</AppBar>
+		</HideOnScroll>
+		<div className={classes.container}/>
+		</React.Fragment>
 	);
 }


### PR DESCRIPTION
Added the following to the material-ui theme type

```js

palette: {
competitionPrimary,
competitionSecondary
}

```

Note that now in order to use the competition defined color themes, we will have to use `theme.palette.competitionPrimary.main` etc. Also note that we'll have to style to text colors accordingly. [Here's ](https://github.com/saranshgrover/nodus/blob/theme-conflicts-4/client/src/components/Overview/OverviewFilterChips.js#L59)an example of how I did it for the FilterChips 